### PR TITLE
Add early version of Spring Security configurations

### DIFF
--- a/1 Introduction/00050-Backend.md
+++ b/1 Introduction/00050-Backend.md
@@ -1,6 +1,6 @@
 ## Backend
 
-Backend functionality of the platform is implemented with Controllers from Spring framework and can be easily extended to handle new functionality. Also the Spring-layer is very light on top and could be substituted with another if needed.
+Backend functionality of the platform is implemented with Controllers from Spring Framework and can be easily extended to handle new functionality. Also the Spring-layer is very light on top and could be substituted with another if needed.
 
 The server-side codebase can be divided into two parts:
 - the application that can be customized for a specific need

--- a/4 Server application/00010-ServerApplication.md
+++ b/4 Server application/00010-ServerApplication.md
@@ -56,7 +56,7 @@ After this, you can use any Maven modules under oskari-server or any of its mana
 
 ## Spring Controllers
 
-Oskari-server uses Spring framework as a wrapper for handling HTTP-requests and security. There are two main Controllers handling most of the requests: `MapController.java`and `ActionRouteController.java`.
+Oskari-server uses Spring Framework as a wrapper for handling HTTP-requests and security. There are two main Controllers handling most of the requests: `MapController.java`and `ActionRouteController.java`.
 
 Under `servlet-map` [module](https://github.com/oskariorg/oskari-server/tree/master/servlet-map/src/main/java/org/oskari/spring/controllers)
 

--- a/4 Server application/00020-MavenModules.md
+++ b/4 Server application/00020-MavenModules.md
@@ -1,7 +1,7 @@
 ## Maven modules
 
 The backend architecture in oskari-server Maven-modules can be divided into three layers: service layer, control layer and interface layer:
-1) The interface layer is very light with Spring framework Controllers for handling requests and can be easily substituted to run as portlets or similar.
+1) The interface layer is very light with Spring Framework Controllers for handling requests and can be easily substituted to run as portlets or similar.
 2) The controllers pass concrete HTTP-requests on to Oskari control-modules that can further process the requests and write responses.
 3) Services are used by the control-modules to handle business-logic. The service-modules could (in theory) be used in any Java-based software as libraries.
 

--- a/4 Server application/00060-Authentication.md
+++ b/4 Server application/00060-Authentication.md
@@ -1,11 +1,20 @@
-## Authentication
-
-This section should give information about Spring framework configurations and what applications can do to provide customized configurations.
-
 ## Authentication and user management (requires backend)
+
+This section should give information about Spring Framework configurations and how applications can provide customized authentication and user management configurations.
 
 Oskari has bundles for user management and for management of layers' priviledges. More information about the bundles will be added to this documentation later.
 
+### Spring Security configurations
+
+The Spring Security configurations are located at https://github.com/oskariorg/oskari-server/tree/develop/servlet-map/src/main/java/org/oskari/spring/security.
+
+The configuration enabling an authentication based on Oskari's own database is defined in class `org.oskari.spring.security.database.OskariDatabaseSecurityConfig`. This class configures a `SecurityFilterChain` that uses the `OskariAuthenticationProvider`. Additionally, it sets up a form-based login and allows all requests (`permitAll`) while still handling user state.
+
+`OskariAuthenticationProvider` implements Spring Security's `AuthenticationProvider` interface. It performs the actual database-based login and verification for users.
+
+The configuration is active only when the `LoginDatabase` profile is enabled. This configuration can be replaced (for example, with a different SecurityFilterChain implementation) by defining a custom configuration under a new profile and setting the profile in `oskari-ext.properties` (`oskari.profiles=NewLoginConfiguration`).
+
+The `DatabaseUserService`, presented in chapter [User Management](../5%20Functionalities/02000-UserManagement.md), can be used for user management even when a custom Spring Security configuration is in place. It is also possible to provide a custom user service implementation by creating a class that extends UserService.
 
 ### SSO authentication support
 

--- a/5 Functionalities/02000-UserManagement.md
+++ b/5 Functionalities/02000-UserManagement.md
@@ -1,6 +1,6 @@
 ## User management
 
-Some Oskari modules utilize role-based user management, allowing users with different roles to access specific functionalities. For example, only logged-in users can view certain layers or spesific user groups can add or edit map layers within the service. The spring security framework that Oskari uses can be customized to different use cases.
+Some Oskari modules utilize role-based user management, allowing users with different roles to access specific functionalities. For example, only logged-in users can view certain layers or spesific user groups can add or edit map layers within the service. The Spring Security framework that Oskari uses can be customized to different use cases.
 
 ### How to use user authentication
 


### PR DESCRIPTION
I added a short explanation of the authentication setup, including information that I found missing when implementing a custom solution. I also suggest combining chapters 4.10 and 4.11, as the topics are closely related. Does this approach make sense, or were there other plans for these chapters?