### PR TITLE
Add some attribute configs to docs

### DIFF
--- a/9 Usage instructions/00200-UsingLayerAdmin.md
+++ b/9 Usage instructions/00200-UsingLayerAdmin.md
@@ -120,6 +120,16 @@ In the `JSON` tab, you can further customize the map layer in more detail and ch
 
 ![Layer form tab JSON](../resources/images/admin/layereditor-json.png)
 
+There are some special configurations that can be enabled through the JSON-tab:
+
+| Attribute | Type | Default |
+| --------- | ---- | ------------- |
+| `forceProxy` | boolean | false |
+| `ignoreCoverage` | boolean | false |
+
+- `forceProxy` can be used to force requests to the layer service to be proxied through the Oskari-server. This can be used to hide API keys on URLs etc.
+- `ignoreCoverage` removes the coverage information gathered from metadata service or service capabilities. Useful if the service or metadata provides erronous coverage geometry as layer is not shown if user tries to view it outside the coverage geometry
+
 #### Permissions tab
 
 In the `Permissions`, you can define who can use the map layer and how they can use it.


### PR DESCRIPTION

<img width="859" height="934" alt="image" src="https://github.com/user-attachments/assets/c50cd6e9-3311-44c5-816e-cad7de46d2d0" />

Having the explanation/meaning on the same table made it look bad with the key breaking to rows and table headings going all over the place so decided to add the explanations beneath the table. Still looks like the table contain more info, but the long explanations were too long.